### PR TITLE
Revert "Updated vimrc with set smartindent"

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -90,10 +90,6 @@ set wrap
 set textwidth=80
 
 
-" Auto indent alignment on new lines
-set smartindent
-
-
 " Adjust the handling of textwidth and colorcolumns when writing a Git
 " commit message. Set the textwidth to 72 and add a second column for the
 " commit title (to 50 characters)


### PR DESCRIPTION
Reverts dfranklinau/dotfiles#1
* * *
I noted a comment on the [Vim Wiki](http://vim.wikia.com/wiki/Indenting_source_code#File-type_based_indentation) regarding the compatibility between `smartindent` and `filetype plugin indent on`. I double checked and, sure enough, I had `filetype plugin indent on` already in my configuration.

I followed this up and found a [post on Stack Overflow](https://stackoverflow.com/a/18415867) stating that `smartindent` has been deprecated in favour of either `cindent` or filetype indenting.

On this note, I've discovered you can create filetype specific indent files, as described on the [same Vim wiki page](http://vim.wikia.com/wiki/Indenting_source_code#Different_settings_for_different_file_types). I think I'll have to revert this pull request but look in to the filetype stuff!